### PR TITLE
Patched iOS error with `drag_start_func_touch`

### DIFF
--- a/src/jquery.nstSlider.js
+++ b/src/jquery.nstSlider.js
@@ -446,17 +446,16 @@
                 touch = original_event.touches[0];
 
             // for touch devices we need to make sure we allow the user to scroll
-            // if the click was too far from the value bar.
+            // if the click was too far from the slider.
             var curY = touch.pageY,
                 curX = touch.pageX;
 
             // is the user allowed to grab if he/she tapped too far from the
-            // actual value bar?
-            var $bar = $this.find(settings.value_bar_selector),
-                ydelta = Math.abs($bar.offset().top - curY),
-                bar_left = $bar.offset().left,
-                xldelta = bar_left - curX,
-                xrdelta = curX - (bar_left + $bar.width());
+            // slider?
+            var ydelta = Math.abs($this.offset().top - curY),
+                slider_left = $this.offset().left,
+                xldelta = slider_left - curX,
+                xrdelta = curX - (slider_left + $this.width());
 
             if (ydelta > settings.touch_tolerance_value_bar_y  ||
                 xldelta > settings.touch_tolerance_value_bar_x ||


### PR DESCRIPTION
We're working on a project at the moment which makes heavy use of nstSlider on iOS devices. We noticed that when using the slider in single-handle mode, with no 'value bar', that it would not respond to touches, or dragging.

I have modified `drag_start_func_touch` to test the touch location against the actual slider itself, rather the value bar, and it appears to work as expected now on iOS.

I also wanted to include a failing test here - but JavaScript testing is not my strong suit and I couldn't figure out how to do it without stubbing some methods (which, again, I was a bit clueless about here).
